### PR TITLE
Add job output download links on script history and modal

### DIFF
--- a/LaunchPad/Controllers/PowerShellController.cs
+++ b/LaunchPad/Controllers/PowerShellController.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace LaunchPad.Controllers
 {
@@ -153,6 +154,28 @@ namespace LaunchPad.Controllers
             var job = _scriptRepository.GetJobById(id);
 
             return PartialView(job);
+        }
+
+        // GET: PowerShell/DownloadJobOutput/1
+        public IActionResult DownloadJobOutput(int id)
+        {
+            var job = _scriptRepository.GetJobById(id);
+            if (job == null)
+            {
+                return NotFound();
+            }
+
+            var script = _scriptRepository.GetScriptById(job.ScriptId);
+            if (script?.Category != null && !UserHasAccessToCategory(script.Category.Id))
+            {
+                return Forbid();
+            }
+
+            var fileName = $"Job_{job.Id}_Output_{job.Date:yyyyMMddHHmmss}.txt";
+            var outcome = job.Outcome ?? string.Empty;
+            var fileBytes = Encoding.UTF8.GetBytes(outcome);
+
+            return File(fileBytes, "text/plain", fileName);
         }
 
         // Job ActionResults

--- a/LaunchPad/Views/PowerShell/JobDetails.cshtml
+++ b/LaunchPad/Views/PowerShell/JobDetails.cshtml
@@ -6,6 +6,7 @@
     @Html.DisplayFor(model => model.Outcome)
 </div>
 <div class="modal-footer">
+    <a class="btn btn-primary" href="@Url.Action("DownloadJobOutput", "PowerShell", new { id = Model.Id })">Download Output</a>
     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
 </div>
 

--- a/LaunchPad/Views/PowerShell/JobHIstory.cshtml
+++ b/LaunchPad/Views/PowerShell/JobHIstory.cshtml
@@ -12,6 +12,9 @@
         <th>
             @Html.DisplayNameFor(model => model.Status)
         </th>
+        <th>
+            Export
+        </th>
     </tr>
 
     @foreach (var item in Model)
@@ -41,6 +44,9 @@
                     <a tabindex="0" job-id="@item.Id" action="JobDetails" class="jobModalButton btn btn-xs btn-success">@Html.DisplayFor(modelItem => item.Status)</a>
                 }
 
+            </td>
+            <td>
+                <a class="btn btn-xs btn-info" href="@Url.Action("DownloadJobOutput", "PowerShell", new { id = item.Id })">Download</a>
             </td>
         </tr>
     }


### PR DESCRIPTION
## Summary
- add a PowerShell controller endpoint that streams job output as a downloadable text file and respects category access
- expose a download action within the job history table and the job details modal so users can export output from either view

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6d1bd847c83309c1caf9cc7fe1b7b